### PR TITLE
LP.css を lp.css にリネーム

### DIFF
--- a/css/lp.css
+++ b/css/lp.css
@@ -25,7 +25,7 @@ body{
     display: flex;
     flex-direction: row;
     align-items: flex-end;
-    background-image: url(images/background.png);
+    background-image: url(../images/background.png);
     background-size: cover;
     background-position: center top;
     background-repeat: no-repeat;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <!--CSS -->
     <link rel="stylesheet" href="https://unpkg.com/ress/dist/ress.min.css">
     <link rel="stylesheet" href="https://fonts.googleaps.com/css?family=Philosopher">
-    <link rel="stylesheet" href="lp.css">
+    <link rel="stylesheet" href="css/lp.css">
     <link rel="stylesheet" href="css/responsive.css">
     
   </head>


### PR DESCRIPTION
サーバー上では `LP.css` と 'lp.css' は区別されるので、小文字に修正しました。
また、css フォルダに lp.css を格納しました。
